### PR TITLE
Add support for passing locals to module.

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,34 @@ posthtml()
 </html>
 ```
 
+## Component options
+
+#### `locals`
+
+Object containing any local variables that you want to be accessible inside the module. Must be a valid JSON object, otherwise it will be ignored.
+
+Example:
+
+```handlebars
+<!-- index.html -->
+<module href="./module.html" locals='{"foo": "strong"}'>
+  <p>Or so they say...</p>
+</module>
+```
+
+```handlebars
+<!-- module.html -->
+<p>The foo is {{ foo }} in this one.</p>
+<content></content>
+```
+
+### Result
+
+```html
+<p>The foo is strong in this one.</p>
+<p>Or so they say...</p>
+```
+
 <h2 align="center">LICENSE</h2>
 
 > MIT License (MIT)

--- a/package-lock.json
+++ b/package-lock.json
@@ -2947,6 +2947,11 @@
         "reusify": "^1.0.4"
       }
     },
+    "fclone": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/fclone/-/fclone-1.0.11.tgz",
+      "integrity": "sha1-EOhdo4v+p/xZk0HClu4ddyZu5kA="
+    },
     "figures": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/figures/-/figures-3.2.0.tgz",
@@ -5234,6 +5239,14 @@
       "requires": {
         "posthtml-parser": "^0.4.1",
         "posthtml-render": "^1.1.5"
+      }
+    },
+    "posthtml-expressions": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/posthtml-expressions/-/posthtml-expressions-1.3.0.tgz",
+      "integrity": "sha512-0S43cljtHP3utEyHQC8J3idz2sfjGPrHAJgNmh2EtK0Bw/QaBJbS0q9DwWkfMap03Ue/nvUtiv7o69XePefW4w==",
+      "requires": {
+        "fclone": "^1.0.11"
       }
     },
     "posthtml-match-helper": {

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
   },
   "homepage": "https://github.com/canvaskisa/posthtml-modules",
   "dependencies": {
+    "posthtml-expressions": "^1.3.0",
     "posthtml-match-helper": "^1.0.1",
     "posthtml-render": "^1.2.0"
   },

--- a/test/locals.spec.html
+++ b/test/locals.spec.html
@@ -1,0 +1,1 @@
+<button type="button">foo is: {{ foo }} - <content></content></button>

--- a/test/test.js
+++ b/test/test.js
@@ -71,3 +71,39 @@ test('Must call plugins option with from value if it is a function', async t => 
     }
   })).process('<div class="test"></div>');
 });
+
+test('Must parse locals if locals prop is passed and it contains a valid JSON string', async t => {
+  const actual = `<div class="test"><module href="./test/locals.spec.html" locals='{"foo": "bar"}'>Test</module></div>`;
+  const expected = `<div class="test"><button type="button">foo is: bar - Test</button></div>`;
+
+  const html = await posthtml().use(plugin()).process(actual).then(result => clean(result.html));
+
+  t.is(html, expected);
+});
+
+test('Must not parse locals if locals prop is passed but is not a valid JSON string', async t => {
+  const actual = `<div class="test"><module href="./test/locals.spec.html" locals="test">Test</module></div>`;
+  const expected = `<div class="test"><button type="button">foo is: {{ foo }} - Test</button></div>`;
+
+  const html = await posthtml().use(plugin()).process(actual).then(result => clean(result.html));
+
+  t.is(html, expected);
+});
+
+test('Must not try to parse locals if locals prop is missing', async t => {
+  const actual = `<div class="test"><module href="./test/locals.spec.html">Test</module></div>`;
+  const expected = `<div class="test"><button type="button">foo is: {{ foo }} - Test</button></div>`;
+
+  const html = await posthtml().use(plugin()).process(actual).then(result => clean(result.html));
+
+  t.is(html, expected);
+});
+
+test('Must not parse locals if locals prop is passed but is empty', async t => {
+  const actual = `<div class="test"><module href="./test/locals.spec.html" locals="">Test</module></div>`;
+  const expected = `<div class="test"><button type="button">foo is: {{ foo }} - Test</button></div>`;
+
+  const html = await posthtml().use(plugin()).process(actual).then(result => clean(result.html));
+
+  t.is(html, expected);
+});

--- a/xo.config.js
+++ b/xo.config.js
@@ -1,9 +1,10 @@
 module.exports = {
   space: true,
   rules: {
+    'prefer-object-spread': 0,
     'capitalized-comments': 0,
-    quotes: ['error', 'single', {allowTemplateLiterals: true}],
+    'unicorn/string-content': 0,
     'promise/prefer-await-to-then': 0,
-    'prefer-object-spread': 0
+    quotes: ['error', 'single', {allowTemplateLiterals: true}]
   }
 };


### PR DESCRIPTION
This PR adds support for passing local variables to modules. If merged, closes #34.

Just like [posthtml-include](https://github.com/posthtml/posthtml-include), it uses [posthtml-expressions](https://github.com/posthtml/posthtml-expressions) to evaluate the parsed JSON string that is provided inside a `locals=""` attribute.

### Example

```handlebars
<!-- module.html -->
<p>The foo is {{ foo }} in this one.</p>
<content></content>
```

```handlebars
<!-- index.html -->
<module href="./module.html" locals='{"foo": "strong"}'>
  <p>Or so they say...</p>
</module>
```

### Result

```html
<p>The foo is strong in this one.</p>
<p>Or so they say...</p>
```