### PR TITLE
Fix nested modules

### DIFF
--- a/index.js
+++ b/index.js
@@ -16,11 +16,7 @@ const expressions = require('posthtml-expressions');
 function processNodeContentWithPosthtml(node, options) {
   return function (content) {
     return processWithPostHtml(options.plugins, path.join(path.dirname(options.from), node.attrs[options.attribute]), content, [
-      parseLocals(node.attrs.locals),
-      function (tree) {
-        // Remove <content> tags and replace them with node's content
-        return tree.match(match('content'), () => node.content || '');
-      }
+      parseLocals(node.attrs.locals)
     ]);
   };
 }
@@ -69,7 +65,10 @@ function parse(options) {
               from: path.join(path.dirname(options.from), node.attrs[options.attribute])
             }))(tree);
           })
-          .then(content => { // remove <module> tag and set inner content
+          .then(tree => {
+            // Remove <content> tags and replace them with node's content
+            const content = tree.match(match('content'), () => node.content || '');
+            // Remove <module> tag and set inner content
             node.tag = false;
             node.content = content;
           })

--- a/test/test.js
+++ b/test/test.js
@@ -30,6 +30,13 @@ test('Must resolve href path correctly', async t => {
   t.is(html, expected);
 });
 
+test('Must process nested modules', async t => {
+  const actual = '<module href="./tree.spec/layout.html">Test<module href="./tree.spec/_/button.html">Button</module></module>';
+  const expected = '<div class="container">Test<button class="button">Button</button></div>';
+  const html = await posthtml().use(plugin({root: './test/tree.spec', from: __filename})).process(actual).then(result => clean(result.html));
+  t.is(html, expected);
+});
+
 test('Must process initial tree if initial prop is passed', async t => {
   const actual = `<div class="test"><module href="./test.spec.html">Test</module></div>`;
   const expected = `<div class="processed"><button type="button">ButtonTest</button></div>`;

--- a/test/tree.spec/_/button.html
+++ b/test/tree.spec/_/button.html
@@ -1,1 +1,1 @@
-<button class="button"></button>
+<button class="button"><content></content></button>

--- a/test/tree.spec/layout.html
+++ b/test/tree.spec/layout.html
@@ -1,0 +1,1 @@
+<div class="container"><content></content></div>


### PR DESCRIPTION
This fixes nested modules by only replacing `<content>` tags after recursively calling `parse()`.

Closes #43 