### PR TITLE
fix: parse options locals when passed as content

### DIFF
--- a/index.js
+++ b/index.js
@@ -77,7 +77,7 @@ function parse(options) {
                 node.attrs &&
                 isJSON(node.attrs.locals)
               ) {
-                return parseLocals(node.attrs.locals)(node.content);
+                return parseLocals(node.attrs.locals, options.locals)(node.content);
               }
 
               return node.content || '';

--- a/test/test.js
+++ b/test/test.js
@@ -150,8 +150,8 @@ test('Must parse locals passed to <content>', async t => {
 });
 
 test('Must parse locals passed as option', async t => {
-  const actual = `<module href="./test/locals.option.spec.html" locals='{"inlineFoo": "inlineBar"}'>test</module>`;
-  const expected = `<div>    Locals attribute: inlineBar    Locals option: optionBar    test</div>`;
+  const actual = `<module href="./test/locals.option.spec.html" locals='{"inlineFoo": "inlineBar"}'>{{ optionFoo }}</module>`;
+  const expected = `<div>    Locals attribute: inlineBar    Locals option: optionBar    optionBar</div>`;
 
   const html = await posthtml().use(plugin({locals: {optionFoo: 'optionBar'}})).process(actual).then(result => clean(result.html));
 


### PR DESCRIPTION
Just realized it wasn't possible to pass a local from `options` to the component `<content>`:

```html
<!-- example.html -->
<div>
    Locals attribute: {{ inlineFoo }}
    Locals option: {{ optionFoo }}
    <content></content>
</div>
```

```html
<!-- index.html -->
<module href="example.html" locals='{"inlineFoo": "inlineBar"}'>As content: {{ optionFoo }}</module>
```

```js
posthtml()
  .use(require('posthtml-modules')({
    locals: {
      optionFoo: 'optionBar'
    }
   }))
  .process(readFileSync('index.html', 'utf8'))
  .then(result => result)
})
```

That was returning:

```
<div>
    Locals attribute: inlineBar
    Locals option: optionBar
    As content: undefined
</div>
```

This PR fixes the issue and the correct variable is rendered:

```diff
<div>
    Locals attribute: inlineBar
    Locals option: optionBar
-   As content: undefined
+   As content: optionBar
</div>
```