### PR TITLE
parse options locals in <content>

### DIFF
--- a/test/test.js
+++ b/test/test.js
@@ -97,7 +97,7 @@ test('Must parse locals if locals prop is passed and it contains a valid JSON st
 
 test('Must not parse locals if locals prop is passed but is not a valid JSON string', async t => {
   const actual = `<div class="test"><module href="./test/locals.spec.html" locals="test">Test</module></div>`;
-  const expected = `<div class="test"><button type="button">foo is: {{ foo }} - Test</button></div>`;
+  const expected = `<div class="test"><button type="button">foo is: undefined - Test</button></div>`;
 
   const html = await posthtml().use(plugin()).process(actual).then(result => clean(result.html));
 
@@ -106,7 +106,7 @@ test('Must not parse locals if locals prop is passed but is not a valid JSON str
 
 test('Must not try to parse locals if locals prop is missing', async t => {
   const actual = `<div class="test"><module href="./test/locals.spec.html">Test</module></div>`;
-  const expected = `<div class="test"><button type="button">foo is: {{ foo }} - Test</button></div>`;
+  const expected = `<div class="test"><button type="button">foo is: undefined - Test</button></div>`;
 
   const html = await posthtml().use(plugin()).process(actual).then(result => clean(result.html));
 
@@ -115,7 +115,7 @@ test('Must not try to parse locals if locals prop is missing', async t => {
 
 test('Must not parse locals if locals prop is passed but is empty', async t => {
   const actual = `<div class="test"><module href="./test/locals.spec.html" locals="">Test</module></div>`;
-  const expected = `<div class="test"><button type="button">foo is: {{ foo }} - Test</button></div>`;
+  const expected = `<div class="test"><button type="button">foo is: undefined - Test</button></div>`;
 
   const html = await posthtml().use(plugin()).process(actual).then(result => clean(result.html));
 

--- a/test/test.js
+++ b/test/test.js
@@ -140,16 +140,25 @@ test('Must use custom attribute name if it was provided in options', async t => 
   t.is(html, expected);
 });
 
-test('Must parse locals passed to <content>', async t => {
-  const actual = `<div class="test"><module href="./test/locals.spec.html" locals='{"foo": "bar"}'>{{ foo }}</module></div>`;
-  const expected = `<div class="test"><button type="button">foo is: bar - bar</button></div>`;
+test('Must parse attribute locals passed to <content>', async t => {
+  const actual = `<module href="./test/locals.option.spec.html" locals='{"inlineFoo": "bar"}'>{{ optionFoo }}</module>`;
+  const expected = `<div>    Locals attribute: bar    Locals option: undefined    undefined</div>`;
 
   const html = await posthtml().use(plugin()).process(actual).then(result => clean(result.html));
 
   t.is(html, expected);
 });
 
-test('Must parse locals passed as option', async t => {
+test('Must parse options locals passed to <content>', async t => {
+  const actual = `<module href="./test/locals.option.spec.html">{{ optionFoo }}</module>`;
+  const expected = `<div>    Locals attribute: undefined    Locals option: optionBar    optionBar</div>`;
+
+  const html = await posthtml().use(plugin({locals: {optionFoo: 'optionBar'}})).process(actual).then(result => clean(result.html));
+
+  t.is(html, expected);
+});
+
+test('Must parse all locals', async t => {
   const actual = `<module href="./test/locals.option.spec.html" locals='{"inlineFoo": "inlineBar"}'>{{ optionFoo }}</module>`;
   const expected = `<div>    Locals attribute: inlineBar    Locals option: optionBar    optionBar</div>`;
 


### PR DESCRIPTION
See the failing test, currently this:

```html
<!-- index.html -->
<module href="example.html">{{ optionFoo }}</module>
```

```html
<!-- example.html -->
<div>
  <content></content>
</div>
```

```js
posthtml()
  .use(require('posthtml-modules')({
    locals: {
      optionFoo: 'optionBar'
    }
   }))
  .process(readFileSync('index.html', 'utf8'))
  .then(result => result)
})
```

Returns:

```html
<div>
  {{ optionFoo }}
</div>
```

But it should return this:

```html
<div>
  optionBar
</div>
```
