### PR TITLE
fix: locals option and no content passed

### DIFF
--- a/index.js
+++ b/index.js
@@ -80,7 +80,7 @@ function parse(options) {
                 return parseLocals(options.locals, node.attrs.locals)(node.content);
               }
 
-              if (!isEmpty(options.locals)) {
+              if (node.content && !isEmpty(options.locals)) {
                 return parseLocals(options.locals)(node.content);
               }
 

--- a/test/test.js
+++ b/test/test.js
@@ -166,3 +166,12 @@ test('Must parse all locals', async t => {
 
   t.is(html, expected);
 });
+
+test('Must work with locals provided in options but no content passed', async t => {
+  const actual = `<module href="./test/locals.option.spec.html"></module>`;
+  const expected = `<div>    Locals attribute: undefined    Locals option: optionBar    </div>`;
+
+  const html = await posthtml().use(plugin({locals: {optionFoo: 'optionBar'}})).process(actual).then(result => clean(result.html));
+
+  t.is(html, expected);
+});


### PR DESCRIPTION
This PR fixes a regression introduced in v0.7.2 where locals passed in the plugin options were parsed no matter if `node.content` existed or not, resulting in a `TypeError: Cannot read property 'tag' of undefined` when you didn't pass any content to a module (i.e. you wanted to use it as an include rather than a module).